### PR TITLE
Bug/cursor and resize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ Before doing your **pull request**, check using `pylint` and `pytest` that there
 pylint .\opencodeblocks\
 ```
 
+Some `pylint` issues can be fixed automatically using `autopep8`, with the following command:
+
+```bash
+autopep8 --in-place --recursive --aggressive opencodeblocks
+```
+
 ```bash
 pytest --cov=opencodeblocks --cov-report=html tests/unit
 ```

--- a/opencodeblocks/graphics/blocks/block.py
+++ b/opencodeblocks/graphics/blocks/block.py
@@ -72,7 +72,10 @@ class OCBBlock(QGraphicsItem, Serializable):
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
 
+        self.setAcceptHoverEvents(True)
+
         self.resizing = False
+        self.resizing_hover = False # Is the mouse hovering over the resizing area ?
         self.moved = False
         self.metadata = {
             'title_metadata': {
@@ -171,6 +174,24 @@ class OCBBlock(QGraphicsItem, Serializable):
             self.sockets_out.remove(socket)
         socket.remove()
         self.update_sockets()
+
+    def hoverMoveEvent(self, event):
+        pos = event.pos()
+        if self._is_in_resize_area(pos):
+            if not self.resizing_hover:
+                self.resizing_hover = True
+                QApplication.setOverrideCursor(Qt.CursorShape.SizeFDiagCursor)
+        elif self.resizing_hover:
+            self.resizing_hover = False
+            QApplication.restoreOverrideCursor()
+
+        return super().hoverMoveEvent(event)
+    def hoverLeaveEvent(self, event):
+        if self.resizing_hover:
+            self.resizing_hover = False
+            QApplication.restoreOverrideCursor()
+
+        return super().hoverLeaveEvent(event)
 
     def mousePressEvent(self, event:QGraphicsSceneMouseEvent):
         """ OCBBlock reaction to a mousePressEvent. """

--- a/opencodeblocks/graphics/blocks/block.py
+++ b/opencodeblocks/graphics/blocks/block.py
@@ -175,7 +175,7 @@ class OCBBlock(QGraphicsItem, Serializable):
         socket.remove()
         self.update_sockets()
 
-    def hoverMoveEvent(self, event):
+    def hoverMoveEvent(self, event:QGraphicsSceneHoverEvent):
         """ Triggered when hovering over a block """
         pos = event.pos()
         if self._is_in_resize_area(pos):

--- a/opencodeblocks/graphics/blocks/block.py
+++ b/opencodeblocks/graphics/blocks/block.py
@@ -176,6 +176,7 @@ class OCBBlock(QGraphicsItem, Serializable):
         self.update_sockets()
 
     def hoverMoveEvent(self, event):
+        """ Triggered when hovering over a block """
         pos = event.pos()
         if self._is_in_resize_area(pos):
             if not self.resizing_hover:
@@ -187,6 +188,7 @@ class OCBBlock(QGraphicsItem, Serializable):
 
         return super().hoverMoveEvent(event)
     def hoverLeaveEvent(self, event):
+        """ Triggered when the mouse stops hovering over a block """
         if self.resizing_hover:
             self.resizing_hover = False
             QApplication.restoreOverrideCursor()

--- a/opencodeblocks/graphics/blocks/block.py
+++ b/opencodeblocks/graphics/blocks/block.py
@@ -133,8 +133,8 @@ class OCBBlock(QGraphicsItem, Serializable):
 
     def _is_in_resize_area(self, pos:QPointF):
         """ Return True if the given position is in the block resize_area. """
-        return self.width - pos.x() < 2 * self.edge_size \
-            and self.height - pos.y() < 2 * self.edge_size
+        return self.width - self.edge_size*2 < pos.x() \
+            and self.height - self.edge_size*2 <  pos.y()
 
     def get_socket_pos(self, socket:OCBSocket) -> Tuple[float]:
         """ Get a socket position to place them on the block sides. """
@@ -211,7 +211,7 @@ class OCBBlock(QGraphicsItem, Serializable):
     def mousePressEvent(self, event:QGraphicsSceneMouseEvent):
         """ OCBBlock reaction to a mousePressEvent. """
         pos = event.pos()
-        if self._is_in_resize_area(pos) and event.buttons() == Qt.MouseButton.LeftButton:
+        if self.resizing_hover and event.buttons() == Qt.MouseButton.LeftButton:
             self._start_resize(pos)
         super().mousePressEvent(event)
 

--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -5,37 +5,60 @@
 
 from typing import Optional
 
-from PyQt5.QtCore import Qt, QByteArray
+from PyQt5.QtCore import Qt, QByteArray, QPointF
 from PyQt5.QtGui import QPainter, QPainterPath, QPixmap
-from PyQt5.QtWidgets import QStyleOptionGraphicsItem, QWidget, QGraphicsProxyWidget, QLabel
+from PyQt5.QtWidgets import QStyleOptionGraphicsItem, QWidget, QGraphicsProxyWidget, QLabel, \
+    QGraphicsSceneMouseEvent, QApplication
 
 from opencodeblocks.graphics.blocks.block import OCBBlock
 from opencodeblocks.graphics.pyeditor import PythonEditor
 
 class OCBCodeBlock(OCBBlock):
 
-    """ Code Block. """
+    """ 
+    Code Block
+
+    Features an area to edit code as well as a panel to display the output.
+
+    """
 
     def __init__(self, **kwargs):
+        """
+        Note that self.output_panel_height < self.height,
+        because the output panel is part of the display.
+        Moreover, the following is always true:
+        output_panel_height + source_panel_height + edge_size*2 + title_height == height
+        """
         super().__init__(block_type='code', **kwargs)
+        
+
+        self.output_panel_height = 100
+        self._min_output_panel_height = 20
+        self._min_source_editor_height = 20
+
+        assert self.height - self.output_panel_height \
+         - self.title_height - self.edge_size*2 > 0
+
         self.source_editor = self.init_source_editor()
         self.display = self.init_display()
         self.stdout = ""
         self.image = ""
 
+        self.resizing_source_code = False
+
+        self.update_all() # Set the geometry of display and source_editor
+
     def init_source_editor(self):
         """ Initialize the python source code editor. """
         source_editor_graphics = QGraphicsProxyWidget(self)
         source_editor = PythonEditor(self)
-        source_editor.setGeometry(
-            int(self.edge_size),
-            int(self.edge_size + self.title_height),
-            int(self.width - 2*self.edge_size),
-            int(self.height - self.title_height - 2*self.edge_size)
-        )
         source_editor_graphics.setWidget(source_editor)
         source_editor_graphics.setZValue(-1)
         return source_editor_graphics
+
+    def _editor_widget_height(self):
+        return self.height - self.title_height - 2*self.edge_size \
+                    - self.output_panel_height
 
     def update_all(self):
         """ Update the code block parts. """
@@ -45,14 +68,14 @@ class OCBCodeBlock(OCBBlock):
                 int(self.edge_size),
                 int(self.edge_size + self.title_height),
                 int(self._width - 2*self.edge_size),
-                int(self.height - self.title_height - 2*self.edge_size)
+                int(self._editor_widget_height())
             )
             display_widget = self.display.widget()
             display_widget.setGeometry(
                 int(self.edge_size),
-                int(self.height + self.edge_size),
+                int(self.height - self.output_panel_height - self.edge_size),
                 int(self.width - 2*self.edge_size),
-                int(self.height*0.3 - 2*self.edge_size)
+                int(self.output_panel_height)
             )
         super().update_all()
 
@@ -69,7 +92,7 @@ class OCBCodeBlock(OCBBlock):
 
     @property
     def stdout(self) -> str:
-        """ Code output. """
+        """ Code output, without errors """
         return self._stdout
     @stdout.setter
     def stdout(self, value:str):
@@ -111,23 +134,96 @@ class OCBCodeBlock(OCBBlock):
         super().paint(painter, option, widget)
         path_title = QPainterPath()
         path_title.setFillRule(Qt.FillRule.WindingFill)
-        path_title.addRoundedRect(0, 0, self.width, 1.3*self.height,
+        path_title.addRoundedRect(0, 0, self.width, self.height,
             self.edge_size, self.edge_size)
         painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(self._brush_background)
         painter.drawPath(path_title.simplified())
+    
+
+    def _is_in_code_output_resize_area(self, pos:QPointF):
+        """ Return True if the given position is in the block resize_area. """
+        source_editor_start = self.height - self.output_panel_height - self.edge_size
+
+        return self.width - 2 * self.edge_size < pos.x() and \
+             source_editor_start - self.edge_size < pos.y() < source_editor_start + self.edge_size
+    
+    def hoverMoveEvent(self, event):
+        """ Triggered when hovering over a block """
+        pos = event.pos()
+        if self._is_in_resize_area(pos) or self._is_in_code_output_resize_area(pos):
+            if not self.resizing_hover:
+                self.resizing_hover = True
+                QApplication.setOverrideCursor(Qt.CursorShape.SizeFDiagCursor)
+        elif self.resizing_hover:
+            self.resizing_hover = False
+            QApplication.restoreOverrideCursor()
+        # Don't call super() because this might override the cursor
+    def hoverLeaveEvent(self, event):
+        """ Triggered when the mouse stops hovering over a block """
+        if self.resizing_hover:
+            self.resizing_hover = False
+            QApplication.restoreOverrideCursor()
+        # Don't call super() because this might override the cursor
+
+    def mousePressEvent(self, event:QGraphicsSceneMouseEvent):
+        """ OCBBlock reaction to a mousePressEvent. """
+        pos = event.pos()
+        resizing_source_code = self._is_in_code_output_resize_area(pos)
+        if (self._is_in_resize_area(pos) or resizing_source_code) and \
+                event.buttons() == Qt.MouseButton.LeftButton:
+            self.resize_start = pos
+            self.resizing = True
+            self.resizing_source_code = resizing_source_code
+            QApplication.setOverrideCursor(Qt.CursorShape.SizeFDiagCursor)
+
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event:QGraphicsSceneMouseEvent):
+        """ OCBBlock reaction to a mouseReleaseEvent. """
+        if self.resizing:
+            self.scene().history.checkpoint("Resized block", set_modified=True)
+        self.resizing = False
+        self.resizing_source_code = False
+        QApplication.restoreOverrideCursor()
+        if self.moved:
+            self.moved = False
+            self.scene().history.checkpoint("Moved block", set_modified=True)
+        super().mouseReleaseEvent(event)
+
+    def mouseMoveEvent(self, event:QGraphicsSceneMouseEvent):
+        """ 
+        We override the default resizing behavior as the code part and the display part of the block
+        block can be resized. 
+        """
+        if self.resizing:
+            delta = event.pos() - self.resize_start
+            self.width = max(self.width + delta.x(), self._min_width)
+            
+            height_delta = max(delta.y(),
+                # List of all the quantities that must remain negative.
+                # Mainly: min_height - height must be negative for all elements
+                self._min_output_panel_height - self.output_panel_height,
+                self._min_height - self.height,
+                self._min_source_editor_height - self._editor_widget_height()
+            )
+
+            self.height += height_delta
+            if not self.resizing_source_code:
+                self.output_panel_height += height_delta
+
+            self.resize_start = event.pos()
+            self.title_graphics.setTextWidth(self.width - 2 * self.edge_size)
+            self.update()
+        else:
+            super().mouseMoveEvent(event)
+            self.moved = True
 
     def init_display(self):
-        """ Initialize the ouptput display widget: QLabel """
+        """ Initialize the output display widget: QLabel """
         display_graphics = QGraphicsProxyWidget(self)
         display = QLabel()
         display.setText("")
-        display.setGeometry(
-            int(self.edge_size),
-            int(self.edge_size + self.height),
-            int(self.width - 2*self.edge_size),
-            int(self.height*0.3 - 2*self.edge_size)
-        )
         display_graphics.setWidget(display)
         display_graphics.setZValue(-1)
         return display_graphics

--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -147,7 +147,7 @@ class OCBCodeBlock(OCBBlock):
         """
         source_editor_start = self.height - self.output_panel_height - self.edge_size
 
-        return self.width - 2 * self.edge_size < pos.x() and \
+        return self.width - self.edge_size/2 < pos.x() and \
              source_editor_start - self.edge_size < pos.y() < source_editor_start + self.edge_size
 
 

--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -30,7 +30,7 @@ class OCBCodeBlock(OCBBlock):
         output_panel_height + source_panel_height + edge_size*2 + title_height == height
         """
         super().__init__(block_type='code', **kwargs)
-        
+
 
         self.output_panel_height = 100
         self._min_output_panel_height = 20
@@ -139,7 +139,7 @@ class OCBCodeBlock(OCBBlock):
         painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(self._brush_background)
         painter.drawPath(path_title.simplified())
-    
+
 
     def _is_in_code_output_resize_area(self, pos:QPointF):
         """ Return True if the given position is in the block resize_area. """
@@ -199,7 +199,7 @@ class OCBCodeBlock(OCBBlock):
         if self.resizing:
             delta = event.pos() - self.resize_start
             self.width = max(self.width + delta.x(), self._min_width)
-            
+
             height_delta = max(delta.y(),
                 # List of all the quantities that must remain negative.
                 # Mainly: min_height - height must be negative for all elements

--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -15,7 +15,7 @@ from opencodeblocks.graphics.pyeditor import PythonEditor
 
 class OCBCodeBlock(OCBBlock):
 
-    """ 
+    """
     Code Block
 
     Features an area to edit code as well as a panel to display the output.
@@ -154,7 +154,7 @@ class OCBCodeBlock(OCBBlock):
     def _is_in_resize_area(self, pos:QPointF):
         """ Return True if the given position is in the block resize_area. """
 
-        # This block features 2 resizing areas with 2 different behaviors        
+        # This block features 2 resizing areas with 2 different behaviors
         is_in_bottom_left = super()._is_in_resize_area(pos)
         return is_in_bottom_left or self._is_in_resize_source_code_area(pos)
 

--- a/opencodeblocks/graphics/blocks/codeblock.py
+++ b/opencodeblocks/graphics/blocks/codeblock.py
@@ -91,7 +91,7 @@ class OCBCodeBlock(OCBBlock):
 
     @property
     def stdout(self) -> str:
-        """ Code output, without errors """
+        """ Code output. Be careful, this also includes stderr """
         return self._stdout
     @stdout.setter
     def stdout(self, value:str):

--- a/opencodeblocks/graphics/function_parsing.py
+++ b/opencodeblocks/graphics/function_parsing.py
@@ -22,7 +22,7 @@ def run_cell(cell: str) -> str:
 
 def run_with_variable_output(cell: str) -> None:
     """
-    This is a proof of concept to show that it is possible 
+    This is a proof of concept to show that it is possible
     to collect a variable output from a kernel execution
 
     Here the kernel executes the code and prints the output repeatedly
@@ -33,10 +33,9 @@ def run_with_variable_output(cell: str) -> None:
     """
     kernel.client.execute(cell)
     done = False
-    while done == False:
+    while not done:
         output, done = kernel.update_output()
         print(output)
-
 
 def get_function_name(code: str) -> str:
     """

--- a/opencodeblocks/graphics/kernel.py
+++ b/opencodeblocks/graphics/kernel.py
@@ -47,31 +47,42 @@ class Kernel():
 
     def execute(self, code: str) -> str:
         """
-        Executes code in the kernel and returns the output of the last message sent by the kernel in return
+        Executes code in the kernel and returns the output of the last message sent by the kernel
 
         Args:
-            code: str representing a piece of Python code to execute
+            code: String representing a piece of Python code to execute
 
         Return:
-            output from the last message sent by the kernel in return
+            output from the last message sent by the kernel
         """
         _ = self.client.execute(code)
-        io_msg_content = {}
-        if 'execution_state' in io_msg_content and io_msg_content['execution_state'] == 'idle':
-            return "no output"
-
-        while True:
+        done = False
+        while not done:
             # Check for messages, break the loop when the kernel stops sending messages
-            message = io_msg_content
-            try:
-                io_msg_content = self.client.get_iopub_msg(timeout=1000)[
-                    'content']
-                if 'execution_state' in io_msg_content and io_msg_content['execution_state'] == 'idle':
-                    break
-            except queue.Empty:
-                break
-
+            message, done = self.get_message()
         return self.message_to_output(message)[0]
+
+    def get_message(self) -> Tuple[str, bool]:
+        """
+        Get message in the jupyter kernel
+
+        Args:
+            code: String representing a piece of Python code to execute
+
+        Return:
+            Tuple of:
+                - output from the last message sent by the kernel
+                - boolean repesenting if the kernel as any other message to send.
+        """
+        done = False
+        try:
+            message = self.client.get_iopub_msg(timeout=1000)['content']
+            if 'execution_state' in message and message['execution_state'] == 'idle':
+                done = True
+        except queue.Empty:
+            message = None
+            done = True
+        return message, done
 
     def update_output(self) -> Tuple[str, str, bool]:
         """
@@ -80,19 +91,9 @@ class Kernel():
         Return:
             current output of the kernel; done: bool, True if the kernel has no message to send
         """
-        message = None
-        done = False
-        try:
-            message = self.client.get_iopub_msg(timeout=1000)[
-                'content']
-            if 'execution_state' in message and message['execution_state'] == 'idle':
-                done = True
-        except queue.Empty:
-            done = True
-
-        out, type = self.message_to_output(message)
-
-        return out, type, done
+        message, done = self.get_message()
+        out, _ = self.message_to_output(message)
+        return out, done
 
     def __del__(self):
         """

--- a/opencodeblocks/graphics/kernel.py
+++ b/opencodeblocks/graphics/kernel.py
@@ -19,31 +19,31 @@ class Kernel():
             message: dict representing the a message sent by the kernel
 
         Return:
-            single output found in the message in that order of priority: image > text data > text print > error > nothing
-            type: 'image' or 'text'
+            single output found in the message in that order of priority:
+                image > text data > text print > error > nothing
         """
-        type = 'None'
+        message_type = 'None'
         if 'data' in message:
             if 'image/png' in message['data']:
-                type = 'image'
+                message_type = 'image'
                 # output an image (from plt.plot or plt.imshow)
                 out = message['data']['image/png']
             else:
-                type = 'text'
+                message_type = 'text'
                 # output data as str (for example if code="a=10\na")
                 out = message['data']['text/plain']
         elif 'name' in message and message['name'] == "stdout":
-            type = 'text'
+            message_type = 'text'
             # output a print (print("Hello World"))
             out = message['text']
         elif 'traceback' in message:
-            type = 'text'
+            message_type = 'text'
             # output an error
             out = '\n'.join(message['traceback'])
         else:
-            type = 'text'
+            message_type = 'text'
             out = ''
-        return out, type
+        return out, message_type
 
     def execute(self, code: str) -> str:
         """

--- a/opencodeblocks/graphics/kernel.py
+++ b/opencodeblocks/graphics/kernel.py
@@ -59,7 +59,9 @@ class Kernel():
         done = False
         while not done:
             # Check for messages, break the loop when the kernel stops sending messages
-            message, done = self.get_message()
+            new_message, done = self.get_message()
+            if not done:
+                message = new_message
         return self.message_to_output(message)[0]
 
     def get_message(self) -> Tuple[str, bool]:

--- a/opencodeblocks/graphics/pyeditor.py
+++ b/opencodeblocks/graphics/pyeditor.py
@@ -131,11 +131,11 @@ class PythonEditor(QsciScintilla):
                 # Keep the GUI alive
                 QCoreApplication.processEvents()
                 # Save kernel message and display it
-                output, type, done = kernel.update_output()
+                output, output_type, done = kernel.update_output()
                 if done is False:
-                    if type == 'text':
+                    if output_type == 'text':
                         self.block.stdout = output
-                    elif type == 'image':
+                    elif output_type == 'image':
                         self.block.image = output
         return super().focusOutEvent(event)
 

--- a/opencodeblocks/graphics/qss/dark_resources.py
+++ b/opencodeblocks/graphics/qss/dark_resources.py
@@ -501,9 +501,11 @@ else:
     qt_resource_struct = qt_resource_struct_v2
 
 def qInitResources():
-    QtCore.qRegisterResourceData(rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qRegisterResourceData(rcc_version, qt_resource_struct,
+        qt_resource_name, qt_resource_data)
 
 def qCleanupResources():
-    QtCore.qUnregisterResourceData(rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qUnregisterResourceData(rcc_version, qt_resource_struct,
+        qt_resource_name, qt_resource_data)
 
 qInitResources()

--- a/opencodeblocks/graphics/window.py
+++ b/opencodeblocks/graphics/window.py
@@ -180,7 +180,7 @@ class OCBWindow(QMainWindow):
         for i, window in enumerate(windows):
             child = window.widget()
 
-            text = "%d %s" % (i + 1, child.windowTitle())
+            text = f"{i + 1} {child.windowTitle()}"
             if i < 9:
                 text = '&' + text
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-check
 pytest-pspec
 pylint
 pylint-pytest
+autopep8


### PR DESCRIPTION
This merge request adds 2 main things:
- The cursor changes to "resize" when hovering over the resize area of a block to make this area easy to locate.
- Codeblocks have 2 resize areas, one to resize the display and one to resize the source editor

The pylint score is a bit lower because pylint things that the 2 hover function in `block.py` and `codeblock.py` are too similar but I don't see an easy way to refactor this.