### PR TITLE
:beetle: adds indentation in pyeditor

### DIFF
--- a/opencodeblocks/graphics/pyeditor.py
+++ b/opencodeblocks/graphics/pyeditor.py
@@ -43,7 +43,7 @@ class PythonEditor(QsciScintilla):
         self.setCaretForegroundColor(QColor("#D4D4D4"))
 
         # Indentation
-        self.setAutoIndent(False)
+        self.setAutoIndent(True)
         self.setTabWidth(4)
         self.setIndentationGuides(True)
         self.setIndentationsUseTabs(False)


### PR DESCRIPTION
Sets autoIndentation to true in pyeditor

Pyeditor now saves the amount of indentation: going to a new line starts the line at the previous indentation level

Not perfect because pyeditor when seeing
```
def hello():
```
won't set indentation level to 1
but still better than when autoIndentation is False